### PR TITLE
update canvas dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": "http://github.com/Phrogz/context-blender/issues",
   "license" : "MIT",
   "dependencies": {
-    "canvas": "~1.1"
+    "canvas": "~1.4"
   },
   "devDependencies": {
     "sprintf": "~0.1"


### PR DESCRIPTION
when attempting to install context-blender, the canvas@1.1.6 dependency is failing install script `node-gyp rebuild, supposedly the newer version of canvas fixes this.