### PR TITLE
update canvas dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": "http://github.com/Phrogz/context-blender/issues",
   "license" : "MIT",
   "dependencies": {
-    "canvas": "~1.4"
+    "canvas": "~1.x"
   },
   "devDependencies": {
     "sprintf": "~0.1"


### PR DESCRIPTION
Like previous Pull Requests (ie. [PR#11](https://github.com/Phrogz/context-blender/pull/11))
an error occures during the installation of `canvas`, with latest version of `cairo`. 
```
npm ERR! canvas@1.1.6 install: `node-gyp rebuild`
npm ERR! Exit status 1
```

So, I've use _minor release_ version notation `1.x` — according to [npm guidelines](https://docs.npmjs.com/getting-started/semantic-versioning) — to prevent future PR.

thanks, 
Arthur.